### PR TITLE
🔧 Fix ruff settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,11 +85,13 @@ exclude_lines = [
 packages = ["src/turplanlegger"]
 
 [tool.ruff]
-select = ["E", "W", "Q", "I", "F", "YTT", "C4", "T10", "ICN", "RSE"]
 line-length = 120
 target-version = "py312"
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint]
+select = ["E", "W", "Q", "I", "F", "YTT", "C4", "T10", "ICN", "RSE"]
+
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "single"
 
 [tool.ruff.format]


### PR DESCRIPTION
This PR aims to fix ruff warnings:
```
ruff check                       
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'select' -> 'lint.select'
  - 'flake8-quotes' -> 'lint.flake8-quotes'
```